### PR TITLE
Dodanie możliwości użycia zwykłych okien jak dialogowych

### DIFF
--- a/Nourishment/src/main/java/Other/Main.java
+++ b/Nourishment/src/main/java/Other/Main.java
@@ -58,7 +58,7 @@ public class Main {
         if (!connectinDialog.getResult()){
             System.exit(0);
         }
-        MainWindow mainWindow = new MainWindow(new KonfigView(), "Menu", new MainMenuPanel());
+        MainWindow mainWindow = new MainWindow(null, new KonfigView(), "Menu", new MainMenuPanel());
         mainWindow.setVisible(true);
     }
 }

--- a/Nourishment/src/main/java/View/BasicView/MainWindow.java
+++ b/Nourishment/src/main/java/View/BasicView/MainWindow.java
@@ -11,6 +11,7 @@ import Interfaces.MyWindowManagerInterface;
 import java.awt.BorderLayout;
 import java.io.Serializable;
 import java.util.List;
+import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 
@@ -20,13 +21,29 @@ import javax.swing.JPanel;
  */
 public class MainWindow extends javax.swing.JFrame implements MyWindowInterface{
     private MyWindowManager myWindowManager = null;
+    private JFrame parent;
     
-    public MainWindow(KonfigView konfigView, String title, MyPanelInterface panel) {
+    public MainWindow(MyPanelInterface parent, KonfigView konfigView, String title, MyPanelInterface panel) {
         initComponents();        
         
         myWindowManager = new MyWindowManager();
         myWindowManager.create(this, konfigView, title, panel);
+        if (parent != null){
+            this.parent = getOldestParent ((JPanel) parent);
+        }
+        else{
+            this.parent = null;
+        }
         init();
+    }
+    
+    private JFrame getOldestParent(JComponent panel){
+        if (!(panel.getParent() instanceof JFrame)){
+          return getOldestParent((JComponent) panel.getParent());
+        }
+        else {
+            return (JFrame) panel.getParent();
+        }
     }
     
     @Override
@@ -42,6 +59,7 @@ public class MainWindow extends javax.swing.JFrame implements MyWindowInterface{
             setExtendedState(myWindowManager.getKonfigView().getExtendedState());
             myWindowManager.setResizeListener(this);
         }
+        if (parent != null){parent.setVisible(!b);}
         super.setVisible(b); //To change body of generated methods, choose Tools | Templates.
     }
     
@@ -96,7 +114,7 @@ public class MainWindow extends javax.swing.JFrame implements MyWindowInterface{
         /* Create and display the form */
         java.awt.EventQueue.invokeLater(new Runnable() {
             public void run() {
-                new MainWindow(new KonfigView(), "", null).setVisible(true);
+                new MainWindow(null, new KonfigView(), "", null).setVisible(true);
             }
         });
     }

--- a/Nourishment/src/main/java/View/BasicView/MyWindowManager.java
+++ b/Nourishment/src/main/java/View/BasicView/MyWindowManager.java
@@ -15,10 +15,13 @@ import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowStateListener;
 import javax.swing.KeyStroke;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.plaf.basic.BasicGraphicsUtils;
 
@@ -29,7 +32,7 @@ import javax.swing.plaf.basic.BasicGraphicsUtils;
 public class MyWindowManager implements MyWindowManagerInterface{
     private TitlePanel titlePanel = null;
     private KonfigView konfigView;
-    private MyPanelInterface workingPanel;  
+    private MyPanelInterface workingPanel;
     
     public TitlePanel getTitlePanlel() {
         return titlePanel;
@@ -97,22 +100,24 @@ public class MyWindowManager implements MyWindowManagerInterface{
     public void setResizeListener(Window window){
         window.addComponentListener(new ComponentAdapter() {
             public void componentResized(ComponentEvent componentEvent) {
-                Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
-                Integer taskbarHeight = Toolkit.getDefaultToolkit().getScreenInsets(window.getGraphicsConfiguration()).bottom; 
-                
-                Integer screenHeight = window.getSize().height;
-                Integer screenWidth = window.getSize().width;
-                
-                if (screenHeight > screenSize.height){
-                    screenHeight = screenSize.height - taskbarHeight;
+                if ((window instanceof JFrame) && (((JFrame) window).getExtendedState() == JFrame.NORMAL)){
+                    Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+                    Integer taskbarHeight = Toolkit.getDefaultToolkit().getScreenInsets(window.getGraphicsConfiguration()).bottom; 
+
+                    Integer screenHeight = window.getSize().height;
+                    Integer screenWidth = window.getSize().width;
+
+                    if (screenHeight > screenSize.height){
+                        screenHeight = screenSize.height - taskbarHeight;
+                    }
+
+                    if (screenWidth > screenSize.width){
+                        screenWidth = screenSize.width;
+                    }
+
+                    window.setSize(screenWidth, screenHeight); 
                 }
-                
-                if (screenWidth > screenSize.width){
-                    screenWidth = screenSize.width;
-                }
-                
-                window.setSize(screenWidth, screenHeight);
             }
-        });        
+        });
     }
 }

--- a/Nourishment/src/main/java/View/MainMenuPanel.java
+++ b/Nourishment/src/main/java/View/MainMenuPanel.java
@@ -17,6 +17,7 @@ import Interfaces.MyListPanelInterface;
 import Other.PDFGenerator;
 import View.BasicView.BaseListPanel;
 import View.BasicView.BasePanel;
+import View.BasicView.MainWindow;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -100,7 +101,7 @@ public class MainMenuPanel extends BasePanel{
         konfigView.setDefaultOperationOnClose(WindowConstants.HIDE_ON_CLOSE);
         konfigView.setExtendedState(JFrame.MAXIMIZED_BOTH);
         
-        MainDialog mainWindow = new MainDialog(null, true, konfigView, "Produkty", listaProduktowPanel);        
+        MainWindow mainWindow = new MainWindow(this, konfigView, "Produkty", listaProduktowPanel);        
         mainWindow.getMyWindowManager().unpackWindow(ormManager.askForObjects(Produkty.class));
         
         mainWindow.setVisible(true);
@@ -110,18 +111,18 @@ public class MainMenuPanel extends BasePanel{
         konfigView.setDefaultOperationOnClose(WindowConstants.HIDE_ON_CLOSE);
         konfigView.setExtendedState(JFrame.MAXIMIZED_BOTH);
         
-        MainDialog mainDialog = new MainDialog(null, true, konfigView, "Zarządzanie potrawami", listaPotrawy);
-        mainDialog.getMyWindowManager().unpackWindow(ormManager.askForObjects(Produkty.class));
-        mainDialog.getMyWindowManager().unpackWindow(ormManager.askForObjects(Potrawy.class));
+        MainWindow mainWindow = new MainWindow(this, konfigView, "Zarządzanie potrawami", listaPotrawy);
+        mainWindow.getMyWindowManager().unpackWindow(ormManager.askForObjects(Produkty.class));
+        mainWindow.getMyWindowManager().unpackWindow(ormManager.askForObjects(Potrawy.class));
         
-        mainDialog.setVisible(true);
+        mainWindow.setVisible(true);
     }//GEN-LAST:event_btnPotrawyActionPerformed
 
     private void btnJadlospisActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnJadlospisActionPerformed
         konfigView.setDefaultOperationOnClose(WindowConstants.HIDE_ON_CLOSE);
         konfigView.setExtendedState(JFrame.MAXIMIZED_BOTH);
         
-        MainDialog mainWindow = new MainDialog(null, true, konfigView, "Jadłospis", listaPotrawWDniu);        
+        MainWindow mainWindow = new MainWindow(this, konfigView, "Jadłospis", listaPotrawWDniu);        
         mainWindow.getMyWindowManager().unpackWindow(ormManager.askForObjects(PotrawyWDniu.class));
         
         mainWindow.setVisible(true);       


### PR DESCRIPTION
- dodano możliwość użycia zwykłych okienek jak dialogowych, poprzez dodanie zarządzania widocznością rodzica. W przypadku włączenia kolejnego widoku, rodzic jest niewidoczny. Wyłączając okno, pojawia się rodzic. Unikamy zmian w rodzicu, przy zarządzaniu dzieckiem, zyskujemy zmaksymalizowane okno, co było niemożliwe w oknie dialogowym.